### PR TITLE
BugFix: excise Lua deselect() command from GUIUtils.lua file

### DIFF
--- a/lua/GUIUtils.lua
+++ b/lua/GUIUtils.lua
@@ -611,24 +611,6 @@ function handleWindowResizeEvent()
 end
 
 
-
---- Clears the current selection in the main window or miniConsole window. <br/>
---- (Note: <i>deselect(windowName)</i> is implemented in Core Mudlet.)
----
---- @usage Clear selection in main window.
----   <pre>
----   deselect()
----   </pre>
---- @usage Clear selection in myMiniConsole window.
----   <pre>
----   deselect("myMiniConsole")
----   </pre>
-function deselect()
-	selectString("", 1)
-end
-
-
-
 --- Sets current background color to a named color.
 ---
 --- @usage Set background color to magenta.


### PR DESCRIPTION
There is no need to retain the deselect() command in this external Lua file.  This has been ported from a PR to the main Mudlet repository which has a commit with the same patch to that file.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>