### PR TITLE
Add setHexFgColor and setHexBgColor

### DIFF
--- a/lua/GUIUtils.lua
+++ b/lua/GUIUtils.lua
@@ -1317,3 +1317,27 @@ function setHexFgColor(windowName, colorString)
     setFgColor(colTable.r, colTable.g, colTable.b)
   end
 end
+
+--- Form of setBgColor that accepts a hex color string instead of decimal values
+--- @param windowName Optional name of the window to use the function on
+--- @param colorString hex string for the color to use
+function setHexBgColor(windowName, colorString)
+  local win = colorString and windowName
+  local col = colorString or windowName
+
+  if win == "main" then win = nil end
+
+  if #col ~= 6 then error("setHexFgColor needs a 6 digit hex color code.") end
+
+  local colTable = {
+    r = tonumber(col:sub(1,2), 16),
+    g = tonumber(col:sub(3,4), 16),
+    b = tonumber(col:sub(5,6), 16)
+  }
+
+  if win then
+    setBgColor(win, colTable.r, colTable.g, colTable.b)
+  else
+    setBgColor(colTable.r, colTable.g, colTable.b)
+  end
+end

--- a/lua/GUIUtils.lua
+++ b/lua/GUIUtils.lua
@@ -1293,3 +1293,27 @@ function ansi2decho(text)
 
   return result
 end
+
+--- Form of setFgColor that accepts a hex color string instead of decimal values
+--- @param windowName Optional name of the window to use the function on
+--- @param colorString hex string for the color to use
+function setHexFgColor(windowName, colorString)
+  local win = colorString and windowName
+  local col = colorString or windowName
+
+  if win == "main" then win = nil end
+
+  if #col ~= 6 then error("setHexFgColor needs a 6 digit hex color code.") end
+
+  local colTable = {
+    r = tonumber(col:sub(1,2), 16),
+    g = tonumber(col:sub(3,4), 16),
+    b = tonumber(col:sub(5,6), 16)
+  }
+
+  if win then
+    setFgColor(win, colTable.r, colTable.g, colTable.b)
+  else
+    setFgColor(colTable.r, colTable.g, colTable.b)
+  end
+end

--- a/tests/GUIUtils.lua
+++ b/tests/GUIUtils.lua
@@ -150,7 +150,7 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
       end
       for _, pair in ipairs(hexStrings) do
         setHexFgColor(pair[1])
-        assert.are.same(outputTable, pair[2])
+        assert.are.same(pair[2], outputTable) 
       end
     end)
 

--- a/tests/GUIUtils.lua
+++ b/tests/GUIUtils.lua
@@ -156,4 +156,25 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
 
   end)
 
+  describe("Tests the functionality of setHexBgColor()", function()
+
+    it("Should convert hex string correctly", function()
+      local hexStrings = {
+        {"000000", { r = 0, g = 0, b = 0 }},
+        {"FFFFFF", { r = 255, g = 255, b = 255 }},
+        {"B22222", { r = 178, g = 34, b = 34 }},
+      }
+      local origSetFgColor = setFgColor
+      local outputTable
+      setBgColor = function(r, g, b)
+        outputTable = { r = r, g = g, b = b }
+      end
+      for _, pair in ipairs(hexStrings) do
+        setHexBgColor(pair[1])
+        assert.are.same(pair[2], outputTable) 
+      end
+    end)
+
+  end)
+
 end)

--- a/tests/GUIUtils.lua
+++ b/tests/GUIUtils.lua
@@ -135,4 +135,25 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
 
   end)
 
+  describe("Tests the functionality of setHexFgColor()", function()
+
+    it("Should convert hex string correctly", function()
+      local hexStrings = {
+        {"000000", { r = 0, g = 0, b = 0 }},
+        {"FFFFFF", { r = 255, g = 255, b = 255 }},
+        {"B22222", { r = 178, g = 34, b = 34 }},
+      }
+      local origSetFgColor = setFgColor
+      local outputTable
+      setFgColor = function(r, g, b)
+        outputTable = { r = r, g = g, b = b }
+      end
+      for inp, outp in pairs(hexStrings) do
+        setHexFgColor(inp)
+        assert.are.same(outputTable, outp)
+      end
+    end)
+
+  end)
+
 end)

--- a/tests/GUIUtils.lua
+++ b/tests/GUIUtils.lua
@@ -148,9 +148,9 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
       setFgColor = function(r, g, b)
         outputTable = { r = r, g = g, b = b }
       end
-      for inp, outp in pairs(hexStrings) do
-        setHexFgColor(inp)
-        assert.are.same(outputTable, outp)
+      for _, pair in ipairs(hexStrings) do
+        setHexFgColor(pair[1])
+        assert.are.same(outputTable, pair[2])
       end
     end)
 


### PR DESCRIPTION
There are two way to set colours: `fg` and `bg` (color names) as well as `setFgColor` and `setBgColor` (decimal colors).

This PR adds `setHexFgColor` and `setHexBgColor`, which take a 6 letter hex colour string (`000000` to `FFFFFF`) and apply that colour to the (optional) specified window.